### PR TITLE
fix: ensure that bootstrap is called only a single time

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,14 @@ This provider's versions are compatible with the following versions of Talos:
 
 ## Building and Installing
 
-This control plane provider can be installed with clusterctl.
-Add the following to your clusterctl.yaml:
+This control plane provider can be installed with clusterctl:
 
-```yaml
-providers:
-  - name: "talos"
-    url: "https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml"
-    type: "BootstrapProvider"
-  - name: "talos"
-    url: "https://github.com/rsmitty/cluster-api-control-plane-provider-talos/releases/latest/controlplane-components.yaml"
-    type: "ControlPlaneProvider"
+```bash
+clusterctl init -c talos -b talos -i <infra-provider-of-choice>
 ```
 
-You can then install with `clusterctl init --control-plane "talos" --bootstrap "talos" ...`.
+If you are going to use this provider as part of Sidero management plane, please refer to [Sidero Docs](https://www.sidero.dev/docs/v0.4/getting-started/install-clusterapi/)
+on how to install and configure it.
 
 This project can be built simply by running `make release` from the root directory.
 Doing so will create a file called `_out/control-plane-components.yaml`.
@@ -66,6 +60,16 @@ Note that CACPPT should be deployed as part of a set of controllers for Cluster 
 You will need at least the upstream CAPI components, the Talos bootstrap provider, and an infrastructure provider for v1alpha3 CAPI capabilities.
 
 ## Usage
+
+### Supported Templates
+
+You can use recommended [Cluster API templates](https://github.com/talos-systems/cluster-api-templates) provided by Sidero Labs.
+
+It contains templates for `AWS` and `GCP`, which are verified by the integration tests.
+
+### Creating Your Own Templates
+
+If you wish to craft your own manifests, here is some important info.
 
 CACPPT supports a single API type, a TalosControlPlane.
 You can create YAML definitions of a TalosControlPlane and `kubectl apply` them as part of a larger CAPI cluster deployment.
@@ -86,8 +90,6 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: talos-cp
   controlPlaneConfig:
-    init:
-      generateType: init
     controlplane:
       generateType: controlplane
 ```
@@ -96,11 +98,11 @@ Note you must provide an infrastructure template for your control plane.
 See your infrastructure provider for how to craft that.
 
 Note the generateType mentioned above.
-This is a required value in the spec for both init and controlplane nodes.
+This is a required value in the spec for both controlplane and worker ("join") nodes.
 For a no-frills control plane config, you can simply specify `controlplane` depending on each config section.
 When creating a TalosControlPlane this way, you can then retrieve the talosconfig file that allows for osctl interaction with your nodes by doing something like `kubectl get talosconfig -o yaml talos-cp-xxxx -o jsonpath='{.status.talosConfig}'` after creation.
 
-If you wish to do something more complex, we allow for the ability to supply an entire Talos config file to the resource.
+If you wish to do something more complex, we allow for the ability to supply an entire Talos machine config file to the resource.
 This can be done by setting the generateType to `none` and specifying a `data` field.
 This config file can be generated with `talosctl config generate` and the edited to supply the various options you may desire.
 This full config is blindly copied from the `data` section of the spec and presented under `.status.controlPlaneData` so that the upstream CAPI controllers can see it and make use.
@@ -121,7 +123,7 @@ spec:
         data: |
             version: v1alpha1
             machine:
-            type: init
+            type: controlplane
             token: xxxxxx
             ...
             ...

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -151,6 +151,7 @@ func (suite *IntegrationSuite) SetupSuite() {
 		capi.WithProvider(provider.Name()),
 		capi.WithKubernetesVersion(strings.TrimLeft(env("WORKLOAD_KUBERNETES_VERSION", env("K8S_VERSION", "v1.22.2")), "v")),
 		capi.WithTemplateFile("https://github.com/talos-systems/cluster-api-templates/blob/v1beta1/aws/standard/standard.yaml"),
+		capi.WithControlPlaneNodes(3),
 	)
 	suite.Require().NoError(err)
 
@@ -168,17 +169,8 @@ func (suite *IntegrationSuite) TearDownSuite() {
 	}
 }
 
-// Test01ScaleUp scale control plane nodes up.
-func (suite *IntegrationSuite) Test01ScaleUp() {
-	suite.cluster.Scale(suite.ctx, 3, capi.ControlPlaneNodes) //nolint:errcheck
-
-	suite.Require().NoError(suite.cluster.Health(suite.ctx))
-
-	time.Sleep(2 * time.Second)
-}
-
-// Test02ReconcileMachine remove a machine and wait until cluster gets healthy again.
-func (suite *IntegrationSuite) Test02ReconcileMachine() {
+// Test01ReconcileMachine remove a machine and wait until cluster gets healthy again.
+func (suite *IntegrationSuite) Test01ReconcileMachine() {
 	selector, err := labels.Parse("cluster.x-k8s.io/control-plane")
 	suite.Require().NoError(err)
 
@@ -262,7 +254,7 @@ func (suite *IntegrationSuite) Test02ReconcileMachine() {
 	)
 }
 
-// Test03ScaleDown scale control planes down.
+// Test02ScaleDown scale control planes down.
 func (suite *IntegrationSuite) Test03ScaleDown() {
 	suite.Require().NoError(suite.cluster.Sync(suite.ctx))
 
@@ -274,7 +266,7 @@ func (suite *IntegrationSuite) Test03ScaleDown() {
 	suite.Require().NoError(suite.cluster.Sync(suite.ctx))
 }
 
-// Test04ScaleControlPlaneNoWait scale control plane nodes up and down without waiting.
+// Test03ScaleControlPlaneNoWait scale control plane nodes up and down without waiting.
 func (suite *IntegrationSuite) Test04ScaleControlPlaneNoWait() {
 	ctx, cancel := context.WithCancel(suite.ctx)
 
@@ -290,7 +282,7 @@ func (suite *IntegrationSuite) Test04ScaleControlPlaneNoWait() {
 	suite.Require().NoError(err)
 }
 
-// Test05ScaleControlPlaneToZero try to scale control plane to zero and check that it never does that.
+// Test04ScaleControlPlaneToZero try to scale control plane to zero and check that it never does that.
 func (suite *IntegrationSuite) Test05ScaleControlPlaneToZero() {
 	ctx, cancel := context.WithCancel(suite.ctx)
 


### PR DESCRIPTION
Get TalosControl plane object without cache when checking bootstrap
flag.
Deploy 3 nodes initially in the integration tests to verify that
bootstrap is called only once.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>