### PR TITLE
chore: rename github organization to siderolabs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG PKGS
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
-FROM ghcr.io/talos-systems/ca-certificates:${PKGS} AS pkg-ca-certificates
-FROM ghcr.io/talos-systems/fhs:${PKGS} AS pkg-fhs
+FROM ghcr.io/siderolabs/ca-certificates:${PKGS} AS pkg-ca-certificates
+FROM ghcr.io/siderolabs/fhs:${PKGS} AS pkg-fhs
 
 # The base target provides the base for running various tasks against the source
 # code
@@ -83,5 +83,5 @@ FROM scratch AS container
 COPY --from=pkg-ca-certificates / /
 COPY --from=pkg-fhs / /
 COPY --from=binary /manager /manager
-LABEL org.opencontainers.image.source https://github.com/talos-systems/cluster-api-control-plane-provider-talos
+LABEL org.opencontainers.image.source https://github.com/siderolabs/cluster-api-control-plane-provider-talos
 ENTRYPOINT [ "/manager" ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -18,8 +18,8 @@ GO_LDFLAGS += -s -w
 
 ARTIFACTS := _out
 
-TOOLS ?= ghcr.io/talos-systems/tools:v0.9.0
-PKGS ?= v0.9.0
+TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0
+PKGS ?= v1.0.0
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64

--- a/PROJECT
+++ b/PROJECT
@@ -1,5 +1,5 @@
 domain: controlplane.cluster.x-k8s.io
-repo: github.com/talos-systems/cluster-api-control-plane-provider-talos
+repo: github.com/siderolabs/cluster-api-control-plane-provider-talos
 resources:
 - group: controlplane
   kind: TalosControlPlane

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -82,6 +82,7 @@ func (suite *IntegrationSuite) SetupSuite() {
 	for _, config := range []struct {
 		env          string
 		providerType clusterv1.ProviderType
+		url          string
 	}{
 		{
 			env:          "CONTROL_PLANE_PROVIDER_COMPONENTS",
@@ -90,18 +91,25 @@ func (suite *IntegrationSuite) SetupSuite() {
 		{
 			env:          "BOOTSTRAP_PROVIDER_COMPONENTS",
 			providerType: clusterv1.BootstrapProviderType,
+			url:          "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml",
 		},
 	} {
 		customConfig := os.Getenv(config.env)
 
-		if customConfig != "" {
+		if customConfig != "" || config.url != "" {
 			if clusterctlConfigs.Providers == nil {
 				clusterctlConfigs.Providers = []providerConfig{}
 			}
 
+			url := fmt.Sprintf("file://%s", customConfig)
+
+			if config.url != "" {
+				url = config.url
+			}
+
 			clusterctlConfigs.Providers = append(clusterctlConfigs.Providers, providerConfig{
 				Name:         "talos",
-				URL:          fmt.Sprintf("file://%s", customConfig),
+				URL:          url,
 				ProviderType: config.providerType,
 			})
 		}


### PR DESCRIPTION
Go module import paths still use talos-systems, go.mod module path is
updated.
Introduce url replacement for CABPT in the integration tests.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>