### PR TITLE
refactor: use cached client tracker in the provider

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -17,10 +17,8 @@ import (
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/connrotation"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,41 +39,6 @@ func (k *kubernetesClient) Close() error {
 
 func newDialer() *connrotation.Dialer {
 	return connrotation.NewDialer((&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext)
-}
-
-// kubeconfigForCluster will fetch a kubeconfig secret based on cluster name/namespace,
-// use it to create a clientset, and return it.
-func (r *TalosControlPlaneReconciler) kubeconfigForCluster(ctx context.Context, cluster client.ObjectKey) (*kubernetesClient, error) {
-	kubeconfigSecret := &corev1.Secret{}
-
-	err := r.Client.Get(ctx,
-		types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name + "-kubeconfig",
-		},
-		kubeconfigSecret,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigSecret.Data["value"])
-	if err != nil {
-		return nil, err
-	}
-
-	dialer := newDialer()
-	config.Dial = dialer.DialContext
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return &kubernetesClient{
-		Clientset: clientset,
-		dialer:    dialer,
-	}, nil
 }
 
 // talosconfigForMachine will generate a talosconfig that uses *all* found addresses as the endpoints.
@@ -132,7 +95,7 @@ func (r *TalosControlPlaneReconciler) talosconfigFromWorkloadCluster(ctx context
 		return nil, fmt.Errorf("at least one machine should be provided")
 	}
 
-	clientset, err := r.kubeconfigForCluster(ctx, cluster)
+	c, err := r.Tracker.GetClient(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +109,10 @@ func (r *TalosControlPlaneReconciler) talosconfigFromWorkloadCluster(ctx context
 			return nil, fmt.Errorf("%q machine does not have a nodeRef", machine.Name)
 		}
 
+		var node v1.Node
+
 		// grab all addresses as endpoints
-		node, err := clientset.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
+		err := c.Get(ctx, types.NamespacedName{Name: machine.Status.NodeRef.Name, Namespace: machine.Status.NodeRef.Namespace}, &node)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -13,18 +13,10 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	talosclient "github.com/talos-systems/talos/pkg/machinery/client"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, tcp *controlplanev1.TalosControlPlane, cluster *clusterv1.Cluster, ownedMachines []clusterv1.Machine) error {
-	kubeclient, err := r.kubeconfigForCluster(ctx, util.ObjectKey(cluster))
-	if err != nil {
-		return err
-	}
-
-	defer kubeclient.Close() //nolint:errcheck
-
 	machines := []clusterv1.Machine{}
 
 	for _, machine := range ownedMachines {


### PR DESCRIPTION
Instead of creating workload cluster Kubernetes client each time and
closing it after that, use CAPI standard class to cache the client.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>