### PR TITLE
fix: skip nodes with empty hostname on etcd audit

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -86,6 +86,11 @@ func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context
 		}
 	}
 
+	// we don't need to set endpoints in general here, as endpoints were already pre-populated by the CABPT controller
+	// but we use the `machines` to _limit_ access to a specific machine in some places, and we need to be compatible
+	// with talosconfigFromWorkloadCluster which doesn't rely on Machine's Addresses
+	//
+	// once we're done with Sidero and `init` nodes, we can switch to use `WithNodes` and proper Machine IPs
 	return talosclient.New(ctx, talosclient.WithEndpoints(addrList...), talosclient.WithConfig(t))
 }
 

--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -190,12 +190,12 @@ func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, tcp *contro
 	// Only querying one CP node, so only 1 message should return.
 	memberList := response.Messages[0]
 
-	if len(memberList.Members) == 0 {
-		return nil
-	}
-
 	// For each etcd member, look through the list of machines and see if noderef matches
 	for _, member := range memberList.Members {
+		if member.Hostname == "" {
+			return fmt.Errorf("discovered etcd member with empty hostname: %s", member)
+		}
+
 		present := false
 		for _, machine := range machines {
 			// break apart the noderef name in case it's an fqdn (like in AWS)


### PR DESCRIPTION
When node is just joining the cluster, `etcd members` briefly returns a
node with an empty hostname. If the member is deleted in this state, it
breaks the etcd cluster build and breaks the cluster.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>