### PR TITLE
fix: tcp webhook resource name and version

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,12 +1,21 @@
 policies:
   - type: commit
     spec:
-      headerLength: 89
       dco: true
-      gpg: false
-      imperative: true
+      gpg:
+        required: true
+        identity:
+          gitHubOrganization: siderolabs
+      spellcheck:
+        locale: US
       maximumOfOneCommit: true
-      requireCommitBody: true
+      header:
+        length: 89
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
+      body:
+        required: true
       conventional:
         types:
           - chore
@@ -15,14 +24,29 @@ policies:
           - refactor
           - style
           - test
+          - release
         scopes:
-          - '*'
+          - apid
+          - machined
+          - networkd
+          - talosctl
+          - trustd
+          - talosctl
+          - kernel
+          - security
+          - ^v1.1
   - type: license
     spec:
       skipPaths:
         - .git/
       includeSuffixes:
         - .go
+      excludeSuffixes:
+        - .pb.go
+        - _string.go
+        - _enumer.go
+        - _string_linux.go
+        - zz_generated.deepcopy.go
       header: |
         // This Source Code Form is subject to the terms of the Mozilla Public
         // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/api/v1alpha3/taloscontrolplane_webhook.go
+++ b/api/v1alpha3/taloscontrolplane_webhook.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package v1alpha3
 
 import (
@@ -15,7 +19,7 @@ func (r *TalosControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,versions=v1beta1,name=default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1alpha3-taloscontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=taloscontrolplanes,versions=v1alpha3,name=default.taloscontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Defaulter = &TalosControlPlane{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,18 +12,18 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha3-taloscontrolplane
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  name: default.taloscontrolplane.controlplane.cluster.x-k8s.io
   rules:
   - apiGroups:
     - controlplane.cluster.x-k8s.io
     apiVersions:
-    - v1beta1
+    - v1alpha3
     operations:
     - CREATE
     - UPDATE
     resources:
-    - kubeadmcontrolplanes
+    - taloscontrolplanes
   sideEffects: None

--- a/main.go
+++ b/main.go
@@ -1,18 +1,6 @@
-/*
-
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package main
 


### PR DESCRIPTION
Looks like it was just copy pasted from kubeadm webhook