### PR TITLE
fix: stop reporting negative unavailable replicas

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -580,6 +580,11 @@ func (r *TalosControlPlaneReconciler) updateStatus(ctx context.Context, tcp *con
 		}
 	}
 
+	// fix the case then some Node objects are still visible which were deleted
+	if tcp.Status.ReadyReplicas > tcp.Status.Replicas {
+		tcp.Status.ReadyReplicas = tcp.Status.Replicas
+	}
+
 	tcp.Status.UnavailableReplicas = replicas - tcp.Status.ReadyReplicas
 
 	if tcp.Status.ReadyReplicas > 0 {


### PR DESCRIPTION
When comparing nodes list in the workload clsuter with machine count, we
can see more nodes than machines, so this check removes a case when
stats go weird:

```
NAME                    READY   INITIALIZED   REPLICAS   READY REPLICAS   UNAVAILABLE REPLICAS
management-cluster-cp   true    true          1          2                -1
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>