### PR TITLE
backport: fix: use 'control-plane' Kubernetes node label

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -552,7 +552,7 @@ func (r *TalosControlPlaneReconciler) updateStatus(ctx context.Context, tcp *con
 	}
 
 	nodeSelector := labels.NewSelector()
-	req, err := labels.NewRequirement(constants.LabelNodeRoleMaster, selection.Exists, []string{})
+	req, err := labels.NewRequirement(constants.LabelNodeRoleControlPlane, selection.Exists, []string{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Talos was labeling control plane nodes with both `control-plane` and
`master` labels since Talos 0.8, so it should be safe to do that change.

Talos 1.2.0 is supposed to drop legacy `master` label, so we need to
make sure CACCPT is ready.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit 6fdde729b8551eef897756f42f9bfc0030855623)