### PR TITLE
fix: regenerate kubeconfig on expiration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,6 +60,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes #126

Whenever kubeconfig reaches 50% of expiration, regenerate the secret.

This secret is used my many other CAPI components, so it needs to be up to date.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>