### PR TITLE
fix: log actual error message in the reconcile error

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -240,7 +240,9 @@ func (r *TalosControlPlaneReconciler) reconcile(ctx context.Context, cluster *cl
 	}
 
 	if result.RequeueAfter != 0 {
-		r.Log.Error(err, "reconcile failed", "requeue after", result.RequeueAfter.String())
+		if err != nil {
+			r.Log.Error(err, "reconcile failed", "requeue after", result.RequeueAfter.String(), "error", err.Error())
+		}
 
 		return result, nil
 	}


### PR DESCRIPTION
Looks like the logger extracts only stacktrace from the error passed as the first argument.
Additionally log error as the separate field.