### PR TITLE
fix: attempt etcd leave before deleting a Machine

### DIFF
--- a/controllers/scale.go
+++ b/controllers/scale.go
@@ -120,13 +120,14 @@ func (r *TalosControlPlaneReconciler) scaleDownControlPlane(
 
 	r.Log.Info("deleting machine", "machine", deleteMachine.Name, "node", node.Name)
 
+	leaveErr := r.gracefulEtcdLeave(ctx, c, util.ObjectKey(cluster), *deleteMachine)
+
 	err = r.Client.Delete(ctx, deleteMachine)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	err = r.gracefulEtcdLeave(ctx, c, util.ObjectKey(cluster), *deleteMachine)
-	if err != nil {
+	if leaveErr != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
With Sidero Metal, deleting a machine leads to a super fast power down, and etcd leave doesn't have time to run, which breaks scaling down `2->1`.