### PR TITLE
fix: set a default controller runtime log

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/flags"
@@ -81,6 +82,9 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	diagnosticsOpts := flags.GetDiagnosticsOptions(diagnosticsOptions)
 


### PR DESCRIPTION
See https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/185