### PR TITLE
Propagate ControlPlane label

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -347,6 +347,9 @@ func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, clus
 		Namespace:   tcp.Namespace,
 		OwnerRef:    infraCloneOwner,
 		ClusterName: cluster.Name,
+		Labels: map[string]string{
+			clusterv1.MachineControlPlaneLabel: "",
+		},
 	})
 	if err != nil {
 		conditions.MarkFalse(tcp, controlplanev1.MachinesCreatedCondition, controlplanev1.InfrastructureTemplateCloningFailedReason,


### PR DESCRIPTION
This is so that harvester for lb and others that rely on this label has it.
