### PR TITLE
fix: remove CA bundle

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -167,7 +167,7 @@ steps:
         - sha512
       draft: true
       files:
-        - _out/*
+        - _out/control-plane-talos/*/*
       note: _out/RELEASE_NOTES.md
     when:
       event:

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,10 @@ RUN cd config/manager \
   && cp config/metadata/metadata.yaml /metadata.yaml
 
 FROM scratch AS release
-COPY --from=release-build /control-plane-components.yaml /control-plane-components.yaml
-COPY --from=release-build /metadata.yaml /metadata.yaml
+ARG TAG
+COPY --from=release-build /control-plane-components.yaml /control-plane-talos/${TAG}/control-plane-components.yaml
+COPY --from=release-build /metadata.yaml /control-plane-talos/${TAG}/metadata.yaml
+
 
 FROM build AS binary
 ARG GO_BUILDFLAGS

--- a/config/crd/patches/webhook_in_taloscontrolplanes.yaml
+++ b/config/crd/patches/webhook_in_taloscontrolplanes.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
See https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/pull/195

Also fix the local release assets path, so that provider is local-installable.