### PR TITLE
feat: create machines with the same name as their underlying infrastructure

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -374,7 +374,7 @@ func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, clus
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.SimpleNameGenerator.GenerateName(tcp.Name + "-"),
+			Name:      infraRef.Name,
 			Namespace: tcp.Namespace,
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel:         cluster.Name,


### PR DESCRIPTION
When new control planes are created for a cloud provider that uses a non-standard mechanism to populate hostnames after the network is ready (Hetzner Cloud in my case), you can end up in a situation where multiple services, most prominently etcd, are initialized with the wrong hostname, essentially bricking the node until you wipe the EPHEMERAL volume and reboot.

This issue in isolation can easily be worked around by setting the hostname in the TalosConfig, but this is not as easily done dynamically with CACPPT other than by using the Machine resource's name with `spec.controlPlaneConfig.controlplane.hostname.source=MachineName` on the TalosControlPlane.

The problem with this approach is that the name of the Machine resource is generated by CACPPT and does not really have any direct influence or relation to the name of the infrastructure.

This attempts to work around that by always using the same name as the underlying infrastructure in the Machines created by CACPPT.

I've tested this code on my end and it appears to have solved the issues previously outlined in https://github.com/siderolabs/talos/issues/10105 combined with setting the hostname source on the TalosControlPlane resource.