### PR TITLE
feat: setting up default namespace for the Talos CP InfrastructureTemplate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-12T17:41:17Z by kres 79636f7.
+# Generated on 2025-10-20T18:00:43Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -26,13 +26,12 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/')) && github.event_name == 'pull_request'
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -56,7 +55,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -100,13 +99,12 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/')) && github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/')
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -130,7 +128,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -162,13 +160,12 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/')) && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -192,7 +189,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -230,7 +227,7 @@ jobs:
           sha256sum control-plane-talos/*/* > sha256sum.txt
           sha512sum control-plane-talos/*/* > sha512sum.txt
       - name: release
-        uses: crazy-max/ghaction-github-release@v2
+        uses: softprops/action-gh-release@v2
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-12T17:41:17Z by kres 79636f7.
+# Generated on 2025-10-20T18:00:43Z by kres 46e133d.
 
 "on":
   workflow_run:
@@ -14,8 +14,7 @@ name: slack-notify-failure
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-12T17:41:17Z by kres 79636f7.
+# Generated on 2025-10-20T18:00:43Z by kres 46e133d.
 
 "on":
   workflow_run:
@@ -12,8 +12,7 @@ name: slack-notify
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Get PR number

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-12T17:41:17Z by kres 79636f7.
+# Generated on 2025-10-20T18:00:43Z by kres 46e133d.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@v10.1.0
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -44,9 +44,7 @@ spec:
       sops: true
       buildxOptions:
         enabled: true
-      runners:
-        - self-hosted
-        - generic
+      runnerGroup: generic
       conditions:
         - on-pull-request
       steps:
@@ -64,9 +62,7 @@ spec:
     - name: push
       buildxOptions:
         enabled: true
-      runners:
-        - self-hosted
-        - generic
+      runnerGroup: generic
       conditions:
         - except-pull-request
         - not-on-tag
@@ -83,9 +79,7 @@ spec:
       sops: true
       buildxOptions:
         enabled: true
-      runners:
-        - self-hosted
-        - generic
+      runnerGroup: generic
       conditions:
         - only-on-tag
       steps:

--- a/api/v1alpha3/taloscontrolplane_webhook.go
+++ b/api/v1alpha3/taloscontrolplane_webhook.go
@@ -51,6 +51,10 @@ func defaultTalosControlPlaneSpec(s *TalosControlPlaneSpec, namespace string) {
 		s.Replicas = &replicas
 	}
 
+	if s.InfrastructureTemplate.Namespace == "" {
+		s.InfrastructureTemplate.Namespace = namespace
+	}
+
 	if !strings.HasPrefix(s.Version, "v") {
 		s.Version = "v" + s.Version
 	}


### PR DESCRIPTION
Hello there !
The CACPPT latest release does not supports TalosControlPlane manifests without explicit namespace specification in infrastructureTemplate resource any more (due to CAPI library changes):
```
E1017 11:00:19.544993       1 controller.go:347] "Reconciler error" err="failed to retrieve MetalMachineTemplate bm-ix-m4-stage1-contol-plane: an empty namespace may not be set when a resource name is provided" controller="taloscontrolplane" controllerGroup="controlplane.cluster.x-k8s.io" controllerKind="TalosControlPlane" TalosControlPlane="bm-ix-m4-stage1-ns/bm-ix-m4-stage1-contol-plane" namespace="bm-ix-m4-stage1-ns" name="bm-ix-m4-stage1-contol-plane" reconcileID="f680364c-ef5a-4f08-8fda-330ed8d8f98a"
```
Defaulting infrastructureTemplate namespace with TalosControlPlane ns in webhook looks like a way to bring back manifests to the format [described in README](https://github.com/siderolabs/cluster-api-control-plane-provider-talos/tree/main?tab=readme-ov-file#creating-your-own-templates) (without explicit namespace definition).

What do you guys think about this minor change ?
