### PR TITLE
fix: add WithDefaultGRPCDialOptions to Talos client creation

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -96,7 +96,11 @@ func (r *TalosControlPlaneReconciler) talosconfigForMachines(ctx context.Context
 	// with talosconfigFromWorkloadCluster which doesn't rely on Machine's Addresses
 	//
 	// once we're done with Sidero and `init` nodes, we can switch to use `WithNodes` and proper Machine IPs
-	return talosclient.New(ctx, talosclient.WithEndpoints(addrList...), talosclient.WithConfig(t))
+	return talosclient.New(ctx,
+		talosclient.WithDefaultGRPCDialOptions(),
+		talosclient.WithEndpoints(addrList...),
+		talosclient.WithConfig(t),
+	)
 }
 
 // talosconfigFromWorkloadCluster gets talosconfig and populates endoints using workload cluster nodes.
@@ -169,5 +173,9 @@ func (r *TalosControlPlaneReconciler) talosconfigFromWorkloadCluster(ctx context
 		}
 	}
 
-	return talosclient.New(ctx, talosclient.WithEndpoints(addrList...), talosclient.WithConfig(t))
+	return talosclient.New(ctx,
+		talosclient.WithDefaultGRPCDialOptions(),
+		talosclient.WithEndpoints(addrList...),
+		talosclient.WithConfig(t),
+	)
 }


### PR DESCRIPTION
## Summary

- Add `WithDefaultGRPCDialOptions()` to both `talosclient.New()` calls in `controllers/configs.go`

## Problem

Without `WithDefaultGRPCDialOptions()`, the built-in `DynamicProxyDialer` is never injected into Talos client connections created by the Talos Control Plane provider. This causes gRPC to use its [delegating resolver](https://github.com/grpc/grpc-go/blob/master/internal/resolver/delegatingresolver/delegatingresolver.go) for proxy detection, which has two problems:

1. **Cached environment variables**: It calls `http.ProxyFromEnvironment` which caches env vars via `sync.Once` — setting `HTTPS_PROXY` after any HTTP call in the process has no effect.
2. **Comma-separated hosts**: It cannot parse comma-separated hosts produced by the `talosroundrobin` [resolver](https://github.com/siderolabs/talos/blob/v1.11.0/pkg/machinery/client/connection.go#L169-L183) (e.g., `10.0.0.1:50000,10.0.0.2:50000`), causing proxy detection to return `nil` and bypassing the HTTP CONNECT proxy entirely.

## Solution

This [issue](https://github.com/siderolabs/talos/issues/11536) has been [fixed](https://github.com/siderolabs/talos/pull/11559) for `talosctl`, but not for the talosclient used by the `TalosControlPlaneReconciler`.

Use the already existing `WithDefaultGRPCDialOptions()`. This doesn't change the default behavior of the TalosControlPlaneReconciler, and enables us to set a proxy for HTTP (gRPC) calls.

With `WithDefaultGRPCDialOptions()`, `DynamicProxyDialer` is set as `grpc.WithContextDialer`, which causes gRPC to [bypass the delegating resolver entirely](https://github.com/grpc/grpc-go/blob/v1.75.1/resolver_wrapper.go#L83-L92), solving both issues via the public API.

`DynamicProxyDialer` already:
- Reads `HTTPS_PROXY` on every dial (no caching)
- Handles HTTP CONNECT proxy negotiation
- Falls back to direct dialing when no proxy is configured
