### PR TITLE
fix: prevent etcd health check deadlock during maxSurge=0 scale-down

### DIFF
--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -24,7 +24,8 @@ func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, tcp *
 	machines := []clusterv1.Machine{}
 
 	for _, machine := range ownedMachines {
-		if machine.ObjectMeta.DeletionTimestamp.IsZero() {
+		if machine.ObjectMeta.DeletionTimestamp.IsZero() &&
+			machine.Annotations["controlplane.cluster.x-k8s.io/etcd-leaving"] != "true" {
 			machines = append(machines, machine)
 		}
 	}

--- a/controllers/scale.go
+++ b/controllers/scale.go
@@ -120,6 +120,19 @@ func (r *TalosControlPlaneReconciler) scaleDownControlPlane(
 
 	r.Log.Info("deleting machine", "machine", deleteMachine.Name, "node", node.Name)
 
+	// Mark machine as leaving etcd so health check skips it even if reconciliation
+	// crashes between gracefulEtcdLeave and Client.Delete (prevents deadlock where
+	// stopped etcd without DeletionTimestamp fails health checks forever).
+	annotations := deleteMachine.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations["controlplane.cluster.x-k8s.io/etcd-leaving"] = "true"
+	deleteMachine.SetAnnotations(annotations)
+	if err := r.Client.Update(ctx, deleteMachine); err != nil {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
 	leaveErr := r.gracefulEtcdLeave(ctx, c, *deleteMachine)
 
 	err = r.Client.Delete(ctx, deleteMachine)


### PR DESCRIPTION
## Summary

Fixes a deadlock in `scaleDownControlPlane()` when `maxSurge=0` and the reconciliation crashes between `gracefulEtcdLeave()` and `Client.Delete()`.

## Problem

In `scale.go`, the scale-down flow is:
1. `gracefulEtcdLeave()` — stops etcd on the machine, removes from cluster
2. `r.Client.Delete(deleteMachine)` — sets DeletionTimestamp

If the controller crashes between steps 1 and 2, the machine has stopped etcd but no DeletionTimestamp. On the next reconciliation, `etcdHealthcheck()` only filters by DeletionTimestamp — so the stopped-etcd machine passes the filter, health check fails, and the controller is permanently deadlocked.

## Fix

- Add annotation `controlplane.cluster.x-k8s.io/etcd-leaving=true` **before** `gracefulEtcdLeave()` via `Client.Update()` (crash-safe)
- `etcdHealthcheck()` now also skips machines with this annotation

Minimal change: no new CRD fields, backwards compatible, annotation only set during active scale-down.

## Test plan

- [x] Reproduced deadlock in production (4-node CP, maxSurge=0)
- [x] Verified fix resolves the deadlock
- [x] Rolling update proceeds correctly