### PR TITLE
fix: spread control plane machines across failure domains (least-used)

### DIFF
--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"reflect"
 	"sort"
 	"strings"
@@ -318,16 +317,48 @@ func (r *TalosControlPlaneReconciler) getControlPlaneMachinesForCluster(ctx cont
 }
 
 // getFailureDomain will return a slice of failure domains from the cluster status.
+// Only returns domains where ControlPlane is true (or not explicitly false).
 func (r *TalosControlPlaneReconciler) getFailureDomain(_ context.Context, cluster *clusterv1.Cluster) []string {
 	if cluster.Status.FailureDomains == nil {
 		return nil
 	}
 
 	retList := []string{}
-	for key := range cluster.Status.FailureDomains {
-		retList = append(retList, key)
+	for key, fd := range cluster.Status.FailureDomains {
+		if fd.ControlPlane {
+			retList = append(retList, key)
+		}
 	}
+	sort.Strings(retList)
 	return retList
+}
+
+// pickFailureDomain selects the failure domain with the fewest existing machines.
+// This ensures control plane nodes are spread evenly across availability zones.
+func pickFailureDomain(failureDomains []string, existingMachines []clusterv1.Machine) string {
+	if len(failureDomains) == 0 {
+		return ""
+	}
+
+	// Count existing machines per failure domain.
+	counts := make(map[string]int, len(failureDomains))
+	for _, fd := range failureDomains {
+		counts[fd] = 0
+	}
+	for i := range existingMachines {
+		if existingMachines[i].Spec.FailureDomain != nil {
+			counts[*existingMachines[i].Spec.FailureDomain]++
+		}
+	}
+
+	// Pick the domain with the fewest machines (first in sorted order for determinism).
+	best := failureDomains[0]
+	for _, fd := range failureDomains[1:] {
+		if counts[fd] < counts[best] {
+			best = fd
+		}
+	}
+	return best
 }
 
 func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, cluster *clusterv1.Cluster, tcp *controlplanev1.TalosControlPlane, first bool) (ctrl.Result, error) {
@@ -396,7 +427,13 @@ func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, clus
 
 	failureDomains := r.getFailureDomain(ctx, cluster)
 	if len(failureDomains) > 0 {
-		machine.Spec.FailureDomain = &failureDomains[rand.Intn(len(failureDomains))]
+		// Fetch existing CP machines to determine least-used failure domain.
+		existingMachines, err := r.getControlPlaneMachinesForCluster(ctx, util.ObjectKey(cluster))
+		if err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to get existing machines for failure domain selection")
+		}
+		fd := pickFailureDomain(failureDomains, existingMachines.Items)
+		machine.Spec.FailureDomain = &fd
 	}
 
 	if err := r.Client.Create(ctx, machine); err != nil {


### PR DESCRIPTION
## Problem

CACPPT assigns failure domains randomly (`rand.Intn`), which can place all CP nodes in the same AZ. With 3 replicas across 3 AZs, random selection has a 1/9 chance of all-same-AZ placement — we observed this consistently in production.

Additionally, the `getFailureDomain` function doesn't filter by `ControlPlane: true`, which was reported in #239.

## Fix

1. **Filter failure domains by `ControlPlane=true`** — only consider domains marked for control plane use (fixes #239)
2. **Replace random selection with least-used algorithm** — count existing CP machines per domain, pick the domain with the fewest machines
3. **Sort failure domain list** for deterministic selection when counts are equal

This matches the spreading behavior of KubeadmControlPlane (KCP) which uses a similar least-used algorithm.

## Testing

Tested with CAPA on AWS (eu-central-1, 3 AZs, 3 CP replicas). Before: all 3 CPs in eu-central-1b. After: one CP per AZ.