### PR TITLE
fix: spread control plane machines across failure domains (least-used)

### DIFF
--- a/controllers/failuredomain_test.go
+++ b/controllers/failuredomain_test.go
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// machineInFailureDomain returns a control plane machine placed in the given failure domain.
+func machineInFailureDomain(name, failureDomain string, deleting bool) clusterv1.Machine {
+	machine := clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if failureDomain != "" {
+		machine.Spec.FailureDomain = pointer.String(failureDomain)
+	}
+
+	if deleting {
+		machine.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		machine.ObjectMeta.Finalizers = []string{clusterv1.MachineFinalizer}
+	}
+
+	return machine
+}
+
+func TestGetFailureDomain(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name           string
+		failureDomains clusterv1.FailureDomains
+		expected       []string
+	}{
+		{
+			name:           "nil failure domains",
+			failureDomains: nil,
+			expected:       nil,
+		},
+		{
+			name:           "empty failure domains",
+			failureDomains: clusterv1.FailureDomains{},
+			expected:       nil,
+		},
+		{
+			name: "filters out non control plane domains",
+			failureDomains: clusterv1.FailureDomains{
+				"a": clusterv1.FailureDomainSpec{ControlPlane: true},
+				"b": clusterv1.FailureDomainSpec{ControlPlane: false},
+				"c": clusterv1.FailureDomainSpec{ControlPlane: true},
+			},
+			expected: []string{"a", "c"},
+		},
+		{
+			name: "falls back to all domains when none are marked for control plane",
+			failureDomains: clusterv1.FailureDomains{
+				"c": clusterv1.FailureDomainSpec{ControlPlane: false},
+				"a": clusterv1.FailureDomainSpec{ControlPlane: false},
+				"b": clusterv1.FailureDomainSpec{ControlPlane: false},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name: "returns sorted list",
+			failureDomains: clusterv1.FailureDomains{
+				"c": clusterv1.FailureDomainSpec{ControlPlane: true},
+				"a": clusterv1.FailureDomainSpec{ControlPlane: true},
+				"b": clusterv1.FailureDomainSpec{ControlPlane: true},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := &clusterv1.Cluster{
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: tt.failureDomains,
+				},
+			}
+
+			r := &TalosControlPlaneReconciler{}
+
+			assert.Equal(t, tt.expected, r.getFailureDomain(context.Background(), cluster))
+		})
+	}
+}
+
+func TestPickFailureDomain(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name           string
+		failureDomains []string
+		machines       []clusterv1.Machine
+		expected       string
+	}{
+		{
+			name:           "empty failure domains",
+			failureDomains: nil,
+			machines:       nil,
+			expected:       "",
+		},
+		{
+			name:           "single failure domain",
+			failureDomains: []string{"a"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "a", false),
+			},
+			expected: "a",
+		},
+		{
+			name:           "no machines picks first sorted domain",
+			failureDomains: []string{"a", "b", "c"},
+			machines:       nil,
+			expected:       "a",
+		},
+		{
+			name:           "picks least used domain",
+			failureDomains: []string{"a", "b", "c"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "a", false),
+				machineInFailureDomain("cp-2", "b", false),
+				machineInFailureDomain("cp-3", "a", false),
+				machineInFailureDomain("cp-4", "c", false),
+				machineInFailureDomain("cp-5", "c", false),
+			},
+			expected: "b",
+		},
+		{
+			name:           "deterministic tie break picks first sorted domain",
+			failureDomains: []string{"a", "b", "c"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "a", false),
+				machineInFailureDomain("cp-2", "b", false),
+				machineInFailureDomain("cp-3", "c", false),
+			},
+			expected: "a",
+		},
+		{
+			name:           "ignores machines being deleted",
+			failureDomains: []string{"a", "b"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "a", false),
+				machineInFailureDomain("cp-2", "b", true),
+			},
+			expected: "b",
+		},
+		{
+			name:           "ignores machines without failure domain",
+			failureDomains: []string{"a", "b"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "", false),
+				machineInFailureDomain("cp-2", "a", false),
+			},
+			expected: "b",
+		},
+		{
+			name:           "ignores machines in unknown failure domains",
+			failureDomains: []string{"a", "b"},
+			machines: []clusterv1.Machine{
+				machineInFailureDomain("cp-1", "unknown", false),
+				machineInFailureDomain("cp-2", "a", false),
+			},
+			expected: "b",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, pickFailureDomain(tt.failureDomains, tt.machines))
+		})
+	}
+}

--- a/controllers/scale.go
+++ b/controllers/scale.go
@@ -35,7 +35,7 @@ func (r *TalosControlPlaneReconciler) scaleUpControlPlane(ctx context.Context, c
 	// Create a new Machine w/ join
 	r.Log.Info("scaling up control plane", "Desired", desiredReplicas, "Existing", numMachines)
 
-	return r.bootControlPlane(ctx, cluster, tcp, false)
+	return r.bootControlPlane(ctx, cluster, tcp, collections.ToMachineList(controlPlane.Machines).Items, false)
 }
 
 func (r *TalosControlPlaneReconciler) scaleDownControlPlane(

--- a/controllers/taloscontrolplane_controller.go
+++ b/controllers/taloscontrolplane_controller.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"reflect"
 	"sort"
 	"strings"
@@ -318,19 +317,69 @@ func (r *TalosControlPlaneReconciler) getControlPlaneMachinesForCluster(ctx cont
 }
 
 // getFailureDomain will return a slice of failure domains from the cluster status.
+//
+// Only returns domains where ControlPlane is true, and falls back to all domains if none are explicitly marked for control plane.
+// The result is sorted for deterministic selection.
 func (r *TalosControlPlaneReconciler) getFailureDomain(_ context.Context, cluster *clusterv1.Cluster) []string {
 	if cluster.Status.FailureDomains == nil {
 		return nil
 	}
 
-	retList := []string{}
-	for key := range cluster.Status.FailureDomains {
-		retList = append(retList, key)
+	var retList []string
+
+	for key, fd := range cluster.Status.FailureDomains {
+		if fd.ControlPlane {
+			retList = append(retList, key)
+		}
 	}
+
+	if len(retList) == 0 {
+		// pick all failure domains if none are explicitly marked for control plane
+		for key := range cluster.Status.FailureDomains {
+			retList = append(retList, key)
+		}
+	}
+
+	sort.Strings(retList)
+
 	return retList
 }
 
-func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, cluster *clusterv1.Cluster, tcp *controlplanev1.TalosControlPlane, first bool) (ctrl.Result, error) {
+// pickFailureDomain selects the failure domain with the fewest existing machines,
+// matching the spreading behavior of the Cluster API KubeadmControlPlane.
+// This ensures control plane nodes are spread evenly across availability zones.
+func pickFailureDomain(failureDomains []string, existingMachines []clusterv1.Machine) string {
+	if len(failureDomains) == 0 {
+		return ""
+	}
+
+	// Count existing machines per failure domain, ignoring machines being deleted.
+	counts := make(map[string]int, len(failureDomains))
+	for _, fd := range failureDomains {
+		counts[fd] = 0
+	}
+
+	for i := range existingMachines {
+		if existingMachines[i].Spec.FailureDomain != nil && existingMachines[i].DeletionTimestamp.IsZero() {
+			counts[*existingMachines[i].Spec.FailureDomain]++
+		}
+	}
+
+	// Pick the domain with the fewest machines (first in sorted order for determinism).
+	best := failureDomains[0]
+
+	for _, fd := range failureDomains[1:] {
+		if counts[fd] < counts[best] {
+			best = fd
+		}
+	}
+
+	return best
+}
+
+func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, cluster *clusterv1.Cluster, tcp *controlplanev1.TalosControlPlane,
+	existingMachines []clusterv1.Machine, first bool,
+) (ctrl.Result, error) {
 	// Since the cloned resource should eventually have a controller ref for the Machine, we create an
 	// OwnerReference here without the Controller field set
 	infraCloneOwner := &metav1.OwnerReference{
@@ -396,7 +445,8 @@ func (r *TalosControlPlaneReconciler) bootControlPlane(ctx context.Context, clus
 
 	failureDomains := r.getFailureDomain(ctx, cluster)
 	if len(failureDomains) > 0 {
-		machine.Spec.FailureDomain = &failureDomains[rand.Intn(len(failureDomains))]
+		fd := pickFailureDomain(failureDomains, existingMachines)
+		machine.Spec.FailureDomain = &fd
 	}
 
 	if err := r.Client.Create(ctx, machine); err != nil {
@@ -781,7 +831,7 @@ func (r *TalosControlPlaneReconciler) reconcileMachines(ctx context.Context, clu
 		// Create new Machine w/ init
 		logger.Info("initializing control plane", "Desired", desiredReplicas, "Existing", numMachines)
 
-		return r.bootControlPlane(ctx, cluster, tcp, true)
+		return r.bootControlPlane(ctx, cluster, tcp, machines.Items, true)
 	// We are scaling up
 	case numMachines < desiredReplicas && numMachines > 0:
 		return r.scaleUpControlPlane(ctx, cluster, tcp, controlPlane)


### PR DESCRIPTION
## Problem

CACPPT assigns failure domains randomly (`rand.Intn`), which can place all control plane nodes in the same AZ. With 3 replicas across 3 AZs there is a 1/9 chance of all-same-AZ placement — we hit this repeatedly in production. Additionally, `getFailureDomain` does not filter by `ControlPlane: true` (#239).

## Fix

- Filter failure domains by `ControlPlane: true`, **falling back to all domains when none are marked** (fixes #239 without breaking environments that don't mark domains)
- Replace random selection with a least-used algorithm: count existing CP machines per domain (ignoring machines being deleted), pick the domain with the fewest — matching KubeadmControlPlane's spreading behavior
- Sort the domain list for deterministic selection on ties
- Reuse the machine list the reconciler has already fetched instead of issuing a second `List` call inside `bootControlPlane` (no new pre-create error path)
- Add table-driven unit tests for the selection logic (13 cases)

## Why #257's e2e failed ("CP machines never go up")

This supersedes #256 / #257. We root-caused the e2e failure that parked #257: the e2e environment runs in a shared CI VPC where CAPA marks `controlPlane: true` on **only one AZ** (the NLB's). With the fix applied, *correct* least-used placement concentrates all CP machines into that single CP-marked domain — which cannot host them in that environment. The old random placement was accidentally escaping the mis-marked zone. In other words, the second hypothesis in the PR thread — "or our tests are broken" — was the right one: the change exposed an e2e fixture issue rather than breaking bring-up. Marking all AZs `controlPlane: true` in the e2e cluster template (or leaving domains unmarked, which now falls back to all) makes the suite pass with this change.

## Production validation

This exact change has been running in our infrastructure as a fork build (`ghcr.io/truvity/cluster-api-control-plane-talos-controller:v0.5.14-truvity.1`, branch [`truvity/failure-domain-spreading`](https://github.com/truvity/cluster-api-control-plane-provider-talos/tree/truvity/failure-domain-spreading)) deployed via the CAPI Operator on AWS (CAPA + CABPT, Talos v1.13.5, K8s v1.36):

- Multiple full cluster create → delete → recreate cycles
- 3 CP machines consistently spread `eu-central-1a` / `1b` / `1c` on every provision (previously: frequent all-same-AZ)
- CP bring-up, etcd formation, rolling updates and scale-down all healthy; no regressions observed across the cycles
