### PR TITLE
fix: skip remediating machines in etcd health check

### DIFF
--- a/controllers/etcd.go
+++ b/controllers/etcd.go
@@ -14,20 +14,87 @@ import (
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// machinesForEtcdHealthcheck returns the owned machines that should take part in the etcd health
+// check: those that are not being deleted, not leaving etcd (see etcdLeavingAnnotation), and not
+// flagged for remediation by a MachineHealthCheck (MachineOwnerRemediated=False). A machine in any
+// of these states is on its way out, so its stopped or already-removed etcd must not keep
+// EtcdClusterHealthyCondition false and deadlock scale-down, rollout, and remediation.
+func machinesForEtcdHealthcheck(ownedMachines []clusterv1.Machine) []clusterv1.Machine {
+	machines := make([]clusterv1.Machine, 0, len(ownedMachines))
+
+	for _, machine := range ownedMachines {
+		if machine.ObjectMeta.DeletionTimestamp.IsZero() &&
+			machine.Annotations[etcdLeavingAnnotation] != "true" &&
+			!conditions.IsFalse(&machine, clusterv1.MachineOwnerRemediatedCondition) {
+			machines = append(machines, machine)
+		}
+	}
+
+	return machines
+}
+
+// nodeNameForMachine returns the host name used to match a machine against an etcd member: the
+// noderef name, overridden by a MachineHostName address when present, with any domain suffix
+// trimmed (noderef names can be FQDNs, e.g. on AWS). The caller must ensure NodeRef is set.
+func nodeNameForMachine(machine clusterv1.Machine) string {
+	hostname := machine.Status.NodeRef.Name
+
+	for _, address := range machine.Status.Addresses {
+		if address.Type == clusterv1.MachineHostName {
+			hostname = address.Address
+
+			break
+		}
+	}
+
+	// break apart the noderef name in case it's an fqdn (like in AWS)
+	hostname, _, _ = strings.Cut(hostname, ".")
+
+	return hostname
+}
 
 func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, tcp *controlplanev1.TalosControlPlane, ownedMachines []clusterv1.Machine) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 
-	machines := []clusterv1.Machine{}
+	machines := machinesForEtcdHealthcheck(ownedMachines)
+
+	// If every owned machine is on its way out (deleting, leaving, or being remediated) there is
+	// nothing left to verify. Reporting etcd healthy here would open the scale-down/rollout gate
+	// without a single member checked, so treat it as unhealthy until a machine is back in the set.
+	if len(ownedMachines) > 0 && len(machines) == 0 {
+		return fmt.Errorf("all %d owned control plane machines are excluded from the etcd health check", len(ownedMachines))
+	}
+
+	// Node names of the machines that must be etcd members (expectedNodeNames) and of every owned
+	// machine (ownedNodeNames). A member of an excluded machine still matches an owned machine and
+	// is tolerated; a member matching no owned machine is an orphan. Skip the machine-to-member
+	// matching while any machine still lacks a noderef: it is new and gets matched on a later pass,
+	// the same assumption auditEtcd makes.
+	expectedNodeNames := make(map[string]struct{}, len(machines))
+	ownedNodeNames := make(map[string]struct{}, len(ownedMachines))
+	allNodeRefsSet := true
 
 	for _, machine := range ownedMachines {
-		if machine.ObjectMeta.DeletionTimestamp.IsZero() &&
-			machine.Annotations[etcdLeavingAnnotation] != "true" {
-			machines = append(machines, machine)
+		if machine.Status.NodeRef == nil {
+			allNodeRefsSet = false
+
+			continue
 		}
+
+		ownedNodeNames[strings.ToLower(nodeNameForMachine(machine))] = struct{}{}
+	}
+
+	for _, machine := range machines {
+		if machine.Status.NodeRef == nil {
+			continue
+		}
+
+		expectedNodeNames[strings.ToLower(nodeNameForMachine(machine))] = struct{}{}
 	}
 
 	params := make([]any, 0, len(machines)*2)
@@ -81,23 +148,37 @@ func (r *TalosControlPlaneReconciler) etcdHealthcheck(ctx context.Context, tcp *
 			}
 
 			for _, message := range resp.Messages {
-				actualMembers := len(message.Members)
-				expectedMembers := len(machines)
-
 				node := message.Metadata.GetHostname()
 
-				// check that the count of members is the same on all nodes
-				if actualMembers != expectedMembers {
-					return fmt.Errorf("%s: expected to have %d members, got %d", node, expectedMembers, actualMembers)
-				}
+				present := make(map[string]struct{}, len(message.Members))
 
-				// check that member list is the same on all nodes
 				for _, member := range message.Members {
+					present[strings.ToLower(member.Hostname)] = struct{}{}
+
+					// check that the member list is the same on all nodes
 					if _, found := members[member.Hostname]; i > 0 && !found {
 						return fmt.Errorf("%s: found extra etcd member %s", node, member.Hostname)
 					}
 
 					members[member.Hostname] = struct{}{}
+
+					// A member matching no owned machine is an orphan (auditEtcd force-removes
+					// these). A member of an excluded machine still matches an owned machine, so
+					// it is tolerated. Skipped while a machine lacks a noderef and can't be matched.
+					if allNodeRefsSet {
+						if _, ok := ownedNodeNames[strings.ToLower(member.Hostname)]; !ok {
+							return fmt.Errorf("%s: etcd member %q does not match any control plane machine", node, member.Hostname)
+						}
+					}
+				}
+
+				// Every machine that must be a member has to have one: a missing member means the
+				// etcd cluster is short a node. An excluded machine's member may already be gone,
+				// which is expected, so those are not required here.
+				for name := range expectedNodeNames {
+					if _, ok := present[name]; !ok {
+						return fmt.Errorf("%s: etcd is missing a member for control plane machine %q", node, name)
+					}
 				}
 			}
 
@@ -225,20 +306,7 @@ func (r *TalosControlPlaneReconciler) auditEtcd(ctx context.Context, tcp *contro
 
 		present := false
 		for _, machine := range machines.Items {
-			hostname := machine.Status.NodeRef.Name
-
-			for _, address := range machine.Status.Addresses {
-				if address.Type == clusterv1.MachineHostName {
-					hostname = address.Address
-
-					break
-				}
-			}
-
-			// break apart the noderef name in case it's an fqdn (like in AWS)
-			hostname, _, _ = strings.Cut(hostname, ".")
-
-			if strings.EqualFold(hostname, member.Hostname) {
+			if strings.EqualFold(nodeNameForMachine(machine), member.Hostname) {
 				present = true
 
 				break

--- a/controllers/etcd_test.go
+++ b/controllers/etcd_test.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+)
+
+func newMachine(name string, mutate func(*clusterv1.Machine)) clusterv1.Machine {
+	m := clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if mutate != nil {
+		mutate(&m)
+	}
+
+	return m
+}
+
+func TestMachinesForEtcdHealthcheck(t *testing.T) {
+	deleting := newMachine("deleting", func(m *clusterv1.Machine) {
+		now := metav1.Now()
+		m.DeletionTimestamp = &now
+	})
+	leaving := newMachine("leaving", func(m *clusterv1.Machine) {
+		m.Annotations = map[string]string{etcdLeavingAnnotation: "true"}
+	})
+	remediating := newMachine("remediating", func(m *clusterv1.Machine) {
+		conditions.MarkFalse(m, clusterv1.MachineOwnerRemediatedCondition,
+			"WaitingForRemediation", clusterv1.ConditionSeverityWarning, "")
+	})
+	// A machine whose remediation is already done carries the condition set to True, which is a
+	// distinct branch from the condition being absent: both must stay in the check set.
+	remediated := newMachine("remediated", func(m *clusterv1.Machine) {
+		conditions.MarkTrue(m, clusterv1.MachineOwnerRemediatedCondition)
+	})
+	healthy := newMachine("healthy", nil)
+
+	// deleting, leaving, and remediating machines are all on their way out and must be excluded,
+	// so a single unhealthy member cannot keep EtcdClusterHealthyCondition false forever. The
+	// healthy and already-remediated machines must remain.
+	got := machinesForEtcdHealthcheck([]clusterv1.Machine{deleting, leaving, remediating, remediated, healthy})
+
+	gotNames := map[string]struct{}{}
+	for _, m := range got {
+		gotNames[m.Name] = struct{}{}
+	}
+
+	want := map[string]struct{}{"remediated": {}, "healthy": {}}
+	if len(gotNames) != len(want) {
+		t.Fatalf("expected check set %v, got %v", want, gotNames)
+	}
+
+	for name := range want {
+		if _, ok := gotNames[name]; !ok {
+			t.Fatalf("expected %q in the check set, got %v", name, gotNames)
+		}
+	}
+
+	// When every owned machine is on its way out, the check set must be empty. etcdHealthcheck
+	// relies on this to refuse a healthy verdict instead of running zero checks.
+	if got := machinesForEtcdHealthcheck([]clusterv1.Machine{deleting, leaving, remediating}); len(got) != 0 {
+		t.Fatalf("expected an empty check set when all machines are excluded, got %d", len(got))
+	}
+}
+
+func TestNodeNameForMachine(t *testing.T) {
+	withNodeRef := func(nodeName string, addresses ...clusterv1.MachineAddress) clusterv1.Machine {
+		return newMachine("m", func(m *clusterv1.Machine) {
+			m.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
+			m.Status.Addresses = addresses
+		})
+	}
+
+	tests := []struct {
+		name    string
+		machine clusterv1.Machine
+		want    string
+	}{
+		{
+			name:    "noderef name",
+			machine: withNodeRef("node-a"),
+			want:    "node-a",
+		},
+		{
+			name:    "fqdn noderef is trimmed to the first label",
+			machine: withNodeRef("node-a.example.com"),
+			want:    "node-a",
+		},
+		{
+			name: "hostname address overrides the noderef name",
+			machine: withNodeRef("node-a",
+				clusterv1.MachineAddress{Type: clusterv1.MachineHostName, Address: "host-b"}),
+			want: "host-b",
+		},
+		{
+			name: "hostname address is also trimmed to the first label",
+			machine: withNodeRef("node-a",
+				clusterv1.MachineAddress{Type: clusterv1.MachineInternalIP, Address: "10.0.0.1"},
+				clusterv1.MachineAddress{Type: clusterv1.MachineHostName, Address: "host-b.example.com"}),
+			want: "host-b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeNameForMachine(tt.machine); got != tt.want {
+				t.Fatalf("nodeNameForMachine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Exclude machines that are being remediated from the etcd health check, so one unhealthy control plane member no longer deadlocks the whole control plane.

## The problem
`etcdHealthcheck` skipped only machines that were deleting or leaving: a `DeletionTimestamp`, or the `etcd-leaving` annotation from #250. A member that goes unhealthy on its own has neither marker. It stays in the check and fails it forever. `EtcdClusterHealthyCondition` stays false, which blocks scale-down, rollout, and remediation. CACPPT has no remediation path, so nothing removes the bad machine. The control plane is stuck. Full write-up and a workaround: #262.

## The change
Two parts:
- Also skip machines flagged for remediation (`MachineOwnerRemediated=False`), the same way #250 skips leaving machines. The filter moves into a small helper, `machinesForEtcdHealthcheck`, with a unit test the inline code lacked.
- Excluding a machine lowers the expected member count, so the old exact `members == machines` check would then fail on a skipped machine whose etcd member is still present. Replace that count with a membership check: every machine that should be a member must have one; a member matching no owned machine is rejected as an orphan; a member of an excluded machine is tolerated. Members are matched to machines with a shared `nodeNameForMachine` helper, extracted from the identical logic already in `auditEtcd`. If every owned machine is excluded, the check now reports unhealthy instead of passing with nothing verified.

## Notes for review
- **Why a membership check, not just a looser count:** relaxing the count to "at least N" would open the gate but stop catching a genuine extra/orphan member (a real fault the strict check used to surface). Matching members to machines keeps that safety: excluded machines' members are tolerated, true orphans still fail. `auditEtcd` runs just before this and force-removes orphans, but its `MarkTrue` is gated only on `etcdHealthcheck`, so verifying orphans here too avoids a false-healthy when `auditEtcd` hasn't cleaned up yet.
- **Noderef timing:** member-to-machine matching is skipped while any machine still lacks a noderef (new machine, matched on a later pass) — the same assumption `auditEtcd` makes. The per-machine etcd "Running" service check still runs in that window.
- **Scope:** this opens the gate; it does not add remediation. CACPPT has no `reconcileUnhealthyMachines` like KubeadmControlPlane, so an operator still deletes the machine by hand. I can follow up with a remediation path (`gracefulEtcdLeave` + delete, quorum-safe) if that is wanted.
- **Tests:** `machinesForEtcdHealthcheck` (including the all-excluded case) and `nodeNameForMachine` have unit tests; the full `controllers` suite passes locally. The membership check inside `etcdHealthcheck` needs a live Talos client, so it's covered by the integration suite, like #250.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
