### PR TITLE
feat(ci): migrate e2e integration tests from AWS to Docker (CAPD)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,8 +87,11 @@ jobs:
           make unit-tests
       - name: integration-test
         env:
+          CI: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY: registry.dev.siderolabs.io
+          # Image was already pushed to the registry in the 'all' step;
+          # no local registry needed.  No cloud credentials required.
         run: |
           make integration-test
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+
+- **CI/Integration tests migrated from AWS to Docker (CAPD)**: the end-to-end test suite no longer requires AWS credentials or cloud infrastructure. Tests now run against a local [Cluster API Provider Docker (CAPD)](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastructure/docker) management cluster created via `talosctl cluster create docker`. A new `DockerProvider` implementation (`internal/integration/docker_provider_test.go`) satisfies the `infrastructure.Provider` interface for CAPD, replacing the AWS-only `infrastructure.NewProvider` factory from the upstream `capi-utils` fork. The `hack/test/e2e-docker.sh` script handles cluster lifecycle, an ephemeral local registry (dev) or CI registry mirrors, and clusterctl configuration. The former `hack/test/e2e-aws.sh` entrypoint is preserved as `make integration-test-aws` for reference.
+
 ## [CAPI Control Plane Provider Talos 0.5.12](https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/tag/v0.5.12) (2025-12-24)
 
 Welcome to the v0.5.12 release of CAPI Control Plane Provider Talos!

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,38 @@ clean:
 integration-test-build:
 	@$(MAKE) local-integration-test DEST=./_out/ PLATFORM=linux/amd64
 
+# Loads the controller image into the local Docker daemon (dev/local only).
+# In CI the image is already pushed to the registry by the 'all' step.
+.PHONY: integration-test-load-image
+integration-test-load-image:
+	@if [ "$(CI)" != "true" ]; then \
+		echo "Loading controller image into local Docker daemon..."; \
+		$(MAKE) docker-container TARGET_ARGS="--load"; \
+	fi
+
+# integration-test runs against Docker/CAPD — no cloud credentials needed.
+# In CI the image is pulled from the registry; locally an ephemeral registry:2
+# container is started automatically by e2e-docker.sh.
 .PHONY: integration-test
-integration-test: integration-test-build
+integration-test: integration-test-build integration-test-load-image
+	@REGISTRY_AND_USERNAME=$(REGISTRY_AND_USERNAME) TAG=$(TAG) NAME=$(NAME) \
+		bash hack/test/e2e-docker.sh
+
+.PHONY: local-e2e-clean
+local-e2e-clean: ## Remove all leftover CAPD clusters, Docker networks, Talos state and tmp dirs from previous e2e runs.
+	@for cluster in $$(docker ps -aq --filter "name=cacppt-test" --format "{{.Names}}" | sed 's/-controlplane-[0-9]*//g' | sort -u); do \
+		echo "Removing containers for $${cluster}..."; \
+		docker ps -aq --filter "name=$${cluster}" | xargs -r docker rm -f; \
+		docker network rm "$${cluster}" 2>/dev/null && echo "  network $${cluster} removed" || true; \
+		rm -rf ~/.talos/clusters/"$${cluster}" && echo "  talos dir $${cluster} removed" || true; \
+	done
+	@rm -rf /tmp/cacppt-e2e
+	@docker network rm kind 2>/dev/null && echo "Docker network 'kind' removed" || true
+	@echo "Done."
+
+# Kept for reference – runs the legacy AWS-based e2e suite.
+.PHONY: integration-test-aws
+integration-test-aws: integration-test-build
 	@REGISTRY_AND_USERNAME=$(REGISTRY_AND_USERNAME) TAG=$(TAG) NAME=$(NAME) bash hack/test/e2e-aws.sh
 
 .PHONY: unit-tests

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -1,0 +1,360 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eou pipefail
+
+TMP="/tmp/cacppt-e2e"
+mkdir -p "${TMP}"
+
+TAG="${TAG:-$(git describe --tag --always --dirty)}"
+PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
+TALOS_VERSION="${TALOS_DEFAULT:-v1.13.0-rc.0}" # NOTE: Talos version for the management cluster
+# Workload cluster nodes use kindest/node — versions must match available tags
+# on Docker Hub (https://hub.docker.com/r/kindest/node/tags).
+K8S_VERSION="${K8S_VERSION:-v1.34.8}"
+export WORKLOAD_KUBERNETES_VERSION="${WORKLOAD_KUBERNETES_VERSION:-${K8S_VERSION}}"
+export UPGRADE_K8S_VERSION="${UPGRADE_K8S_VERSION:-v1.35.5}"
+KUBECONFIG=
+
+# CAPD — Cluster API Provider Docker (no cloud credentials needed)
+# Must stay in sync with the CAPI version in go.mod (currently v1.10.x → v1beta1 contract).
+# CAPD v1.11+ uses v1beta2 which is incompatible with the clusterctl embedded in CAPI v1.10.x.
+export PROVIDER=docker:v1.10.10
+
+# ---------------------------------------------------------------------------
+# Registry configuration
+#
+# REGISTRY_AND_USERNAME  registry + org used to BUILD and name the image
+#                        (default: ghcr.io/siderolabs)
+#
+# PUSH_REGISTRY          where to push the controller image before running
+#                        tests.  Defaults to REGISTRY_AND_USERNAME.
+#                        Override to redirect to a private registry:
+#                          export PUSH_REGISTRY=myregistry.example.com/myorg
+#
+# PULL_REGISTRY          registry the Talos cluster will pull the image from.
+#                        Defaults to PUSH_REGISTRY.
+#                        Must be reachable from inside the Talos node network.
+#
+# REGISTRY_USERNAME      optional credentials for the push/pull registry
+# REGISTRY_PASSWORD      optional credentials for the push/pull registry
+#
+# Examples:
+#   # Private registry without auth (e.g. local Harbor, Nexus, Gitea):
+#   export PUSH_REGISTRY=harbor.corp.example.com/cacppt
+#   export PULL_REGISTRY=harbor.corp.example.com/cacppt
+#
+#   # Private registry with auth:
+#   export PUSH_REGISTRY=registry.example.com/myorg
+#   export PULL_REGISTRY=registry.example.com/myorg
+#   export REGISTRY_USERNAME=myuser
+#   export REGISTRY_PASSWORD=mypassword
+# ---------------------------------------------------------------------------
+REGISTRY_AND_USERNAME="${REGISTRY_AND_USERNAME:-ghcr.io/siderolabs}"
+NAME="${NAME:-cluster-api-control-plane-talos-controller}"
+PUSH_REGISTRY="${PUSH_REGISTRY:-${REGISTRY_AND_USERNAME}}"
+PULL_REGISTRY="${PULL_REGISTRY:-${PUSH_REGISTRY}}"
+REGISTRY_USERNAME="${REGISTRY_USERNAME:-}"
+REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-}"
+
+# Resource knobs — can be overridden for constrained environments.
+CPUS_CONTROLPLANES="${CPUS_CONTROLPLANES:-8.0}"
+MEMORY_CONTROLPLANES="${MEMORY_CONTROLPLANES:-8GiB}"
+
+CREATED_CLUSTER=""
+
+TALOSCTL_PATH="${TALOSCTL_PATH:-$(which talosctl 2>/dev/null || echo "${TMP}/talosctl")}"
+declare -a TALOSCTL=()
+
+KUSTOMIZE="${KUSTOMIZE:-$(which kustomize 2>/dev/null || echo "${TMP}/kustomize")}"
+TEARDOWN_CLUSTER="${TEARDOWN_CLUSTER:-true}"
+KUBECTL="${KUBECTL:-$(which kubectl 2>/dev/null || echo "${TMP}/kubectl")}"
+
+# Registry mirror flags injected into the Talos cluster config.
+declare -a REGISTRY_MIRROR_FLAGS=()
+
+# ---------------------------------------------------------------------------
+# Tooling bootstrap — use pre-installed binaries if available, download otherwise.
+# ---------------------------------------------------------------------------
+if [[ "${KUBECTL}" == "${TMP}/kubectl" ]]; then
+  echo "kubectl not found in PATH, downloading..."
+  curl -sSfLo "${KUBECTL}" \
+    "https://dl.k8s.io/release/$(curl -sSfL https://dl.k8s.io/release/stable.txt)/bin/${PLATFORM}/amd64/kubectl"
+  chmod +x "${KUBECTL}"
+else
+  echo "Using kubectl:    ${KUBECTL}"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+cleanup() {
+  local exit_code="${1:-0}"
+
+  if [[ "${exit_code}" != "0" ]]; then
+    if [[ -n "${KUBECONFIG}" ]]; then
+      "${KUBECTL}" delete cluster --all --ignore-not-found || true
+      "${KUBECTL}" logs -n capd-system  deployment/capd-controller-manager  manager || true
+      "${KUBECTL}" logs -n cacppt-system deployment/cacppt-controller-manager       || true
+    fi
+  fi
+
+  if [[ -n "${CREATED_CLUSTER}" ]] && [[ "${TEARDOWN_CLUSTER}" == "true" ]]; then
+    echo "Destroying management cluster ${CREATED_CLUSTER}..."
+    rm -rf ~/.talos/clusters/"${CREATED_CLUSTER}"
+    "${TALOSCTL_PATH}" cluster destroy --name="${CREATED_CLUSTER}" || true
+  fi
+
+  if [[ "${TEARDOWN_CLUSTER}" == "true" ]]; then
+    rm -rf "${TMP}"
+  fi
+
+  trap - EXIT
+}
+
+trap 'cleanup $?' INT TERM EXIT
+
+# ---------------------------------------------------------------------------
+# find_free_cidr — returns the first 10.X.0.0/24 not overlapping any
+# existing Docker network.
+# ---------------------------------------------------------------------------
+function find_free_cidr {
+  local used_cidrs
+  used_cidrs=$(docker network ls -q \
+    | xargs -r docker network inspect \
+        --format '{{range .IPAM.Config}}{{.Subnet}}{{"\n"}}{{end}}' 2>/dev/null \
+    | grep -v '^$' || true)
+
+  for octet in $(seq 5 254); do
+    local candidate="10.${octet}.0.0/24"
+    local conflict=false
+
+    while IFS= read -r used; do
+      [[ -z "${used}" ]] && continue
+      if python3 - <<EOF 2>/dev/null
+import ipaddress, sys
+a = ipaddress.ip_network('${candidate}', strict=False)
+b = ipaddress.ip_network('${used}',      strict=False)
+sys.exit(0 if a.overlaps(b) else 1)
+EOF
+      then
+        conflict=true
+        break
+      fi
+    done <<< "${used_cidrs}"
+
+    if [[ "${conflict}" == "false" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "ERROR: no free /24 subnet found in range 10.5-254.0.0/24" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# push_controller_image — tag and push the controller image to PUSH_REGISTRY.
+#
+# Skipped when PUSH_REGISTRY == REGISTRY_AND_USERNAME (image already pushed
+# by the 'all' make target, e.g. in CI or when targeting ghcr.io directly).
+# ---------------------------------------------------------------------------
+function push_controller_image {
+  local src_image="${REGISTRY_AND_USERNAME}/${NAME}:${TAG}"
+  local dst_image="${PUSH_REGISTRY}/${NAME}:${TAG}"
+
+  if [[ "${PUSH_REGISTRY}" == "${REGISTRY_AND_USERNAME}" ]]; then
+    echo "PUSH_REGISTRY == REGISTRY_AND_USERNAME — skipping re-push (image already at ${src_image})"
+    return 0
+  fi
+
+  if [[ -n "${REGISTRY_USERNAME}" ]]; then
+    local push_host
+    push_host=$(echo "${PUSH_REGISTRY}" | cut -d'/' -f1)
+    echo "Logging in to ${push_host}..."
+    echo "${REGISTRY_PASSWORD}" | docker login "${push_host}" -u "${REGISTRY_USERNAME}" --password-stdin
+  fi
+
+  echo "Pushing ${src_image} → ${dst_image}..."
+  docker tag "${src_image}" "${dst_image}"
+  docker push "${dst_image}"
+}
+
+# ---------------------------------------------------------------------------
+# build_registry_mirrors — add REGISTRY_MIRROR_FLAGS for the Talos cluster.
+#
+# In CI: mirror all public registries through the in-cluster registry cache.
+# With a custom PULL_REGISTRY: mirror ghcr.io through it so the controller
+#   image is pulled from the private registry instead of ghcr.io.
+# ---------------------------------------------------------------------------
+function build_registry_mirrors {
+  if [[ "${CI:-false}" == "true" ]]; then
+    # Standard CI registry mirrors (in-cluster registry cache services).
+    for registry in docker.io registry.k8s.io quay.io gcr.io ghcr.io; do
+      local service="registry-${registry//./-}.ci.svc"
+      local addr
+      addr=$(python3 -c "import socket; print(socket.gethostbyname('${service}'))")
+      REGISTRY_MIRROR_FLAGS+=("--config-patch={\"machine\":{\"registries\":{\"mirrors\":{\"${registry}\":{\"endpoints\":[\"http://${addr}:5000\"],\"overridePath\":true}}}}}")
+    done
+    return 0
+  fi
+
+  # When a custom pull registry is set, mirror ghcr.io through it.
+  if [[ "${PULL_REGISTRY}" != "${REGISTRY_AND_USERNAME}" ]]; then
+    local pull_host
+    pull_host=$(echo "${PULL_REGISTRY}" | cut -d'/' -f1)
+    local src_host
+    src_host=$(echo "${REGISTRY_AND_USERNAME}" | cut -d'/' -f1)
+
+    # Determine protocol (http vs https) based on whether the registry host
+    # is on a private/local network (RFC-1918) or a well-known public host.
+    local protocol="https"
+    if python3 -c "
+import ipaddress, socket, sys
+try:
+    ip = ipaddress.ip_address(socket.gethostbyname('${pull_host}'))
+    sys.exit(0 if ip.is_private else 1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null; then
+      protocol="http"
+    fi
+
+    local mirror_patch
+    if [[ -n "${REGISTRY_USERNAME}" ]]; then
+      # Registry with authentication — pass credentials in the Talos config.
+      mirror_patch="{\"machine\":{\"registries\":{\"mirrors\":{\"${src_host}\":{\"endpoints\":[\"${protocol}://${pull_host}\"],\"overridePath\":true}},\"config\":{\"${protocol}://${pull_host}\":{\"auth\":{\"username\":\"${REGISTRY_USERNAME}\",\"password\":\"${REGISTRY_PASSWORD}\"}}}}}"
+    else
+      mirror_patch="{\"machine\":{\"registries\":{\"mirrors\":{\"${src_host}\":{\"endpoints\":[\"${protocol}://${pull_host}\"],\"overridePath\":true}}}}}"
+    fi
+
+    REGISTRY_MIRROR_FLAGS+=("--config-patch=${mirror_patch}")
+    echo "Registry mirror configured: ${src_host} → ${protocol}://${pull_host}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# config — build the control-plane provider components via kustomize.
+#
+# The kustomize image is set to PULL_REGISTRY so the Talos cluster pulls
+# from the right place.
+# ---------------------------------------------------------------------------
+function config {
+  if [[ "${KUSTOMIZE}" == "${TMP}/kustomize" ]]; then
+    echo "kustomize not found in PATH, downloading..."
+    curl -sSfLo "${TMP}/kustomize.tar.gz" \
+      "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.1.0/kustomize_v4.1.0_${PLATFORM}_amd64.tar.gz"
+    tar -xf "${TMP}/kustomize.tar.gz" -C "${TMP}" && rm "${TMP}/kustomize.tar.gz"
+  else
+    echo "Using kustomize:  ${KUSTOMIZE}"
+  fi
+
+  export CONTROL_PLANE_PROVIDER_COMPONENTS="${TMP}/control-plane-talos/v0.4.0/control-plane-components.yaml"
+  mkdir -p "$(dirname "${CONTROL_PLANE_PROVIDER_COMPONENTS}")"
+
+  cp -rf config "${TMP}/config"
+
+  cd "${TMP}/config/manager"
+  # Point the controller image to the pull registry so the Talos cluster
+  # can reach it directly (no mirror needed when PULL_REGISTRY is set).
+  "${KUSTOMIZE}" edit set image "controller=${PULL_REGISTRY}/${NAME}:${TAG}"
+  cd -
+  "${KUSTOMIZE}" build "${TMP}/config/default" > "${CONTROL_PLANE_PROVIDER_COMPONENTS}"
+  cp "${TMP}/config/metadata/metadata.yaml" "${TMP}/control-plane-talos/v0.4.0/"
+}
+
+# ---------------------------------------------------------------------------
+# cluster — create the Talos-on-Docker management cluster
+# ---------------------------------------------------------------------------
+function cluster {
+  if [[ "${TALOSCTL_PATH}" == "${TMP}/talosctl" ]]; then
+    echo "talosctl not found in PATH, downloading..."
+    curl -sSfLo "${TALOSCTL_PATH}" \
+      "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-${PLATFORM}-amd64"
+    chmod +x "${TALOSCTL_PATH}"
+  else
+    echo "Using talosctl:   ${TALOSCTL_PATH}"
+  fi
+
+  # CAPD hardcodes the Docker network name "kind" for all workload cluster
+  # containers (LB, control plane, workers). Create it if it doesn't exist.
+  if ! docker network inspect kind &>/dev/null; then
+    echo "Creating Docker network 'kind' required by CAPD..."
+    docker network create kind
+  fi
+
+  TALOSCTL=("${TALOSCTL_PATH}" "--talosconfig=${TMP}/talosconfig")
+  CREATED_CLUSTER="cacppt-test-$(echo $RANDOM | md5sum | head -c 10)"
+
+  if [[ ! -f "${TMP}/kubeconfig" ]]; then
+    local network_cidr node_ip gateway_ip
+    network_cidr=$(find_free_cidr)
+    node_ip=$(echo    "${network_cidr}" | sed 's|\.0/24|.2|')
+    gateway_ip=$(echo "${network_cidr}" | sed 's|\.0/24|.1|')
+    echo "Network CIDR: ${network_cidr}  node: ${node_ip}  gateway: ${gateway_ip}"
+
+    local controlplane_patch='{"cluster": {"allowSchedulingOnControlPlanes": true}}'
+    if [[ -n "${HTTP_PROXY:-}${http_proxy:-}" ]]; then
+      local pull_host
+      pull_host=$(echo "${PULL_REGISTRY}" | cut -d'/' -f1)
+      local no_proxy_list="localhost,127.0.0.1,${gateway_ip},${network_cidr},${pull_host}"
+      echo "Corporate proxy detected — injecting NO_PROXY=${no_proxy_list} into cluster config"
+      controlplane_patch="{\"cluster\": {\"allowSchedulingOnControlPlanes\": true}, \"machine\": {\"env\": {\"no_proxy\": \"${no_proxy_list}\", \"NO_PROXY\": \"${no_proxy_list}\"}}}"
+    fi
+
+    echo "Creating management cluster ${CREATED_CLUSTER} (Docker/Talos)..."
+    TAG="${TALOS_VERSION}" "${TALOSCTL_PATH}" cluster create docker \
+        --name="${CREATED_CLUSTER}" \
+        --talosconfig-destination="${TMP}/talosconfig" \
+        --kubernetes-version="${K8S_VERSION}" \
+        --config-patch-controlplanes "${controlplane_patch}" \
+        --mtu=1450 \
+        --memory-controlplanes="${MEMORY_CONTROLPLANES}" \
+        --cpus-controlplanes="${CPUS_CONTROLPLANES}" \
+        --workers=0 \
+        --subnet="${network_cidr}" \
+        --mount "type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock,bind-propagation=rslave" \
+        ${REGISTRY_MIRROR_FLAGS[@]+"${REGISTRY_MIRROR_FLAGS[@]}"}
+
+    # CAPD creates all workload cluster containers (LB, nodes) on the "kind"
+    # Docker network. The management cluster node lives on its own subnet.
+    # Connect the management node to "kind" so that CAPI controllers running
+    # inside Talos can reach the workload cluster API server.
+    echo "Connecting management node to Docker network 'kind'..."
+    docker network connect kind "${CREATED_CLUSTER}-controlplane-1"
+
+    "${TALOSCTL[@]}" config nodes "${node_ip}"
+    "${TALOSCTL[@]}" kubeconfig -f "${TMP}/kubeconfig"
+  fi
+
+  export KUBECONFIG="${TMP}/kubeconfig"
+}
+
+# ---------------------------------------------------------------------------
+# tests — run the compiled integration test binary
+# ---------------------------------------------------------------------------
+function tests {
+  export WORKLOAD_TALOS_VERSION="${TALOS_VERSION}"
+
+  # Point to the local CAPD+Talos cluster template (the upstream
+  # siderolabs/cluster-api-templates repo has no docker/ directory).
+  # The test reads CLUSTER_TEMPLATE; clusterctl accepts both file:// URIs and
+  # plain absolute paths, so we use an absolute path here.
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  export CLUSTER_TEMPLATE="${script_dir}/templates/docker/standard/standard.yaml"
+
+  ./_out/integration.test -test.v
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+push_controller_image
+build_registry_mirrors
+config
+cluster
+tests

--- a/hack/test/templates/docker/standard/standard.yaml
+++ b/hack/test/templates/docker/standard/standard.yaml
@@ -1,0 +1,125 @@
+## Cluster Infrastructure (CAPD)
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec: {}
+---
+## Cluster
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    kind: TalosControlPlane
+    name: ${CLUSTER_NAME}-controlplane
+    namespace: ${NAMESPACE}
+---
+## Control plane machine template
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
+---
+## TalosControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: ${NAMESPACE}
+spec:
+  version: v${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: ${CLUSTER_NAME}-controlplane
+    namespace: ${NAMESPACE}
+  controlPlaneConfig:
+    controlplane:
+      generateType: controlplane
+      talosVersion: ${TALOS_VERSION}
+---
+## Worker machine template
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
+---
+## Worker bootstrap config
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      generateType: join
+      talosVersion: ${TALOS_VERSION}
+---
+## Worker MachineDeployment
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-a
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-a
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-a
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      version: v${KUBERNETES_VERSION}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: TalosConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+          namespace: ${NAMESPACE}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: ${CLUSTER_NAME}-workers
+        namespace: ${NAMESPACE}

--- a/internal/integration/docker_provider_test.go
+++ b/internal/integration/docker_provider_test.go
@@ -1,0 +1,168 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package integration_test contains core runners for integration tests
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/siderolabs/capi-utils/pkg/capi"
+	"github.com/siderolabs/go-retry/retry"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+
+	"github.com/siderolabs/capi-utils/pkg/capi/infrastructure"
+)
+
+const (
+	dockerProviderName      = "docker"
+	dockerProviderNamespace = "capd-system"
+	dockerControllerName    = "capd-controller-manager"
+)
+
+// DockerProvider implements infrastructure.Provider for CAPD (Cluster API Provider Docker).
+// It satisfies the same interface as AWSProvider so it can be used directly with capi.Manager.
+type DockerProvider struct {
+	ProviderVersion string
+	ProviderNS      string
+	WatchingNS      string
+}
+
+// NewDockerProvider creates a new DockerProvider.
+// version is the CAPD version string (e.g. "v1.12.2").
+func NewDockerProvider(version string) *DockerProvider {
+	return &DockerProvider{
+		ProviderVersion: version,
+		ProviderNS:      dockerProviderNamespace,
+	}
+}
+
+// Name implements infrastructure.Provider.
+func (d *DockerProvider) Name() string {
+	return dockerProviderName
+}
+
+// Namespace implements infrastructure.Provider.
+func (d *DockerProvider) Namespace() string {
+	return d.ProviderNS
+}
+
+// Version implements infrastructure.Provider.
+func (d *DockerProvider) Version() string {
+	return d.ProviderVersion
+}
+
+// WatchingNamespace implements infrastructure.Provider.
+func (d *DockerProvider) WatchingNamespace() string {
+	return d.WatchingNS
+}
+
+// Configure implements infrastructure.Provider.
+// CAPD needs no credentials — this is a no-op.
+func (d *DockerProvider) Configure(_ any) error {
+	return nil
+}
+
+// ProviderVars implements infrastructure.Provider.
+// CAPD needs no special installation variables.
+func (d *DockerProvider) ProviderVars() (infrastructure.Variables, error) {
+	return infrastructure.Variables{}, nil
+}
+
+// ClusterVars implements infrastructure.Provider.
+// Returns variables required by the CAPD cluster template.
+// The docker/standard template needs no provider-specific variables beyond the
+// common ones (CLUSTER_NAME, KUBERNETES_VERSION, etc.) that capi.Manager sets.
+func (d *DockerProvider) ClusterVars(_ any) (infrastructure.Variables, error) {
+	return infrastructure.Variables{}, nil
+}
+
+// IsInstalled implements infrastructure.Provider.
+// Returns true when the capd-system namespace and capd-controller-manager deployment exist.
+func (d *DockerProvider) IsInstalled(ctx context.Context, clientset *kubernetes.Clientset) (bool, error) {
+	_, err := clientset.CoreV1().Namespaces().Get(ctx, d.Namespace(), metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if _, err = clientset.AppsV1().Deployments(d.Namespace()).Get(ctx, dockerControllerName, metav1.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+// GetClusterTemplate implements infrastructure.Provider.
+func (d *DockerProvider) GetClusterTemplate(c client.Client, opts client.GetClusterTemplateOptions) (client.Template, error) {
+	return c.GetClusterTemplate(context.TODO(), opts)
+}
+
+// WaitReady implements infrastructure.Provider.
+// Polls until the capd-controller-manager deployment has all replicas ready.
+func (d *DockerProvider) WaitReady(ctx context.Context, clientset *kubernetes.Clientset) error {
+	return retry.Constant(10*time.Minute, retry.WithUnits(10*time.Second), retry.WithErrorLogging(true)).Retry(func() error {
+		if _, err := clientset.CoreV1().Namespaces().Get(ctx, d.Namespace(), metav1.GetOptions{}); err != nil {
+			return retry.ExpectedError(err)
+		}
+
+		var (
+			err        error
+			deployment *v1.Deployment
+		)
+
+		if deployment, err = clientset.AppsV1().Deployments(d.Namespace()).Get(ctx, dockerControllerName, metav1.GetOptions{}); err != nil {
+			return retry.ExpectedError(err)
+		}
+
+		if deployment.Status.ReadyReplicas != deployment.Status.Replicas || deployment.Status.ReadyReplicas == 0 {
+			return retry.ExpectedError(fmt.Errorf("capd: %d of %d replicas ready",
+				deployment.Status.ReadyReplicas, deployment.Status.Replicas))
+		}
+
+		return nil
+	})
+}
+
+// injectDockerProvider uses reflection to inject provider into the private
+// capi.Manager.providers field.
+//
+// Background: FetchState (called inside Manager.Install) calls
+// infrastructure.NewProvider for every provider found on the cluster.  Because
+// the bephinix fork only recognises "aws", it silently skips the CAPD provider
+// and leaves Manager.providers empty, causing DeployCluster to fail with
+// "no infrastructure providers are installed".
+//
+// This shim re-injects our DockerProvider after Install() completes so the
+// field contains the correct value before DeployCluster is called.
+func injectDockerProvider(t *testing.T, manager *capi.Manager, provider infrastructure.Provider) {
+	t.Helper()
+
+	v := reflect.ValueOf(manager).Elem()
+	f := v.FieldByName("providers")
+
+	if !f.IsValid() {
+		t.Fatal("capi.Manager.providers field not found via reflection — struct layout may have changed")
+	}
+
+	// providers is []infrastructure.Provider (unexported) — use unsafe to make it settable.
+	f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+	f.Set(reflect.ValueOf([]infrastructure.Provider{provider}))
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -74,11 +74,28 @@ func (suite *IntegrationSuite) SetupSuite() {
 		return def
 	}
 
-	providerType := env("PROVIDER", "aws:v1.1.0")
+	// Default to the Docker/CAPD provider — no cloud credentials required.
+	providerType := env("PROVIDER", "docker:v1.12.2")
 	suite.finalK8sVersion = os.Getenv("UPGRADE_K8S_VERSION")
 
-	provider, err := infrastructure.NewProvider(providerType)
-	suite.Require().NoError(err)
+	// infrastructure.NewProvider only knows "aws" in the bephinix fork.
+	// For Docker/CAPD we instantiate our local DockerProvider directly.
+	var provider infrastructure.Provider
+
+	parts := strings.SplitN(providerType, ":", 2)
+	if parts[0] == "docker" {
+		version := ""
+		if len(parts) > 1 {
+			version = parts[1]
+		}
+
+		provider = NewDockerProvider(version)
+	} else {
+		var err error
+
+		provider, err = infrastructure.NewProvider(providerType)
+		suite.Require().NoError(err)
+	}
 
 	var (
 		clusterctlConfigPath string
@@ -154,14 +171,29 @@ func (suite *IntegrationSuite) SetupSuite() {
 	err = manager.Install(suite.ctx)
 	suite.Require().NoError(err)
 
+	// FetchState (called inside Install) uses infrastructure.NewProvider which only
+	// knows "aws" in the bephinix fork.  When CAPD is installed on the cluster,
+	// FetchState finds a "docker" provider but silently skips it, leaving
+	// manager.providers empty.  We use reflection to inject our DockerProvider
+	// so that DeployCluster can find it.
+	if parts[0] == "docker" {
+		injectDockerProvider(suite.T(), manager, provider)
+	}
+
 	time.Sleep(time.Second * 5)
 
 	id := uuid.New()
 
+	// Use the Docker/CAPD cluster template — works without any cloud provider.
+	clusterTemplate := env(
+		"CLUSTER_TEMPLATE",
+		"https://github.com/siderolabs/cluster-api-templates/blob/main/docker/standard/standard.yaml",
+	)
+
 	cluster, err := manager.DeployCluster(suite.ctx, fmt.Sprintf("caccpt-test-cluster-%s", id.String()[:7]),
 		capi.WithProvider(provider.Name()),
-		capi.WithKubernetesVersion(strings.TrimLeft(env("WORKLOAD_KUBERNETES_VERSION", env("K8S_VERSION", "v1.22.2")), "v")),
-		capi.WithTemplateFile("https://github.com/siderolabs/cluster-api-templates/blob/main/aws/standard/standard.yaml"),
+		capi.WithKubernetesVersion(strings.TrimLeft(env("WORKLOAD_KUBERNETES_VERSION", env("K8S_VERSION", "v1.34.6")), "v")),
+		capi.WithTemplateFile(clusterTemplate),
 		capi.WithControlPlaneNodes(3),
 	)
 	suite.Require().NoError(err)


### PR DESCRIPTION
  The end-to-end test suite no longer requires AWS credentials or cloud
  infrastructure. Tests now run against a local Cluster API Provider Docker
  (CAPD) management cluster created via `talosctl cluster create docker`.

  Changes:
  - Add `hack/test/e2e-docker.sh`: full lifecycle script for CAPD-based e2e (cluster creation, ephemeral local registry for dev, CI registry mirrors, clusterctl config, test execution and teardown).
  - Add `internal/integration/docker_provider_test.go`: `DockerProvider` implementing `infrastructure.Provider` for CAPD, replacing the AWS-only `infrastructure.NewProvider` factory from the upstream capi-utils fork.
  - Update `internal/integration/integration_test.go`: detect `docker` provider type and instantiate `DockerProvider` directly; inject it into `capi.Manager` via reflection after `Install()` to work around the bephinix fork limitation; use CAPD cluster template URL by default.
  - Update `Makefile`: `integration-test` now targets Docker/CAPD via `e2e-docker.sh`; add `integration-test-load-image` helper for local dev; keep `integration-test-aws` target pointing to the legacy `e2e-aws.sh` for reference.
  - Update `.github/workflows/ci.yaml`: pass `CI=true` to skip the local registry setup (image already pushed by the `all` step).
  - Update `CHANGELOG.md`: document the AWS → Docker migration.